### PR TITLE
ANS-105: License Tags

### DIFF
--- a/ans/ANS-105.md
+++ b/ans/ANS-105.md
@@ -1,6 +1,6 @@
 # ANS-105: License Tags
 
-Status: Draft-1
+Status: Draft-2
 
 Authors: Sam Williams <sam@arweave.org>
 
@@ -20,22 +20,26 @@ The license tagging format is composed of a single additional tag on any transac
 
 ### Assigning a License to Transaction Data
 
-In order to publish the data of a transaction under a given transaction format, simply add the following tag:
+In order to publish the data of a transaction under a given transaction format, simply add the following tags:
 
 | Tag Name | _Optional?_ | Tag Value |
 |---|---|---|
 |License|False|TXID of `License Definition`|
+|Title|True|The title of the work|
+|Creator|True|The name/identifier of the creator(s) of the work|
+|Source|True|A link to the source where the material was obtained, if applicable|
 
-### License Definitions
 
-In order to define a license, submit a transaction with the following tags:
+### License or Legal tool Definitions
+
+In order to define a license or related legal tool (such as [CC0](https://wiki.creativecommons.org/wiki/CC0)), submit a transaction with the following tags:
 
 | Tag Name | _Optional?_ | Tag Value |
 |---|---|---|
 |App-Name|True|`"License-Definition"`|
 |Logo|True|TXID of `License Logo`|
 |Short-Name|True|A short 'ticker' with which to refer to the license|
-|Content-Type|True|The MIME type of the contained file, describing the license.|
+|Content-Type|True|The MIME type of the contained file, describing the license|
 
 The **body** of the transaction must contain the legal text of the license being defined.
 
@@ -45,7 +49,7 @@ License Logo transactions should be defined as follows:
 
 | Tag Name | _Optional?_ | Tag Value |
 |---|---|---|
-|Content-Type|False|The MIME type of the contained file.|
+|Content-Type|False|The MIME type of the contained file|
 
 The **body** of the transaction must contain the visual representation of the license's logo.
 

--- a/ans/ANS-105.md
+++ b/ans/ANS-105.md
@@ -1,0 +1,54 @@
+# ANS-105: License Tags
+
+Status: Draft-1
+
+Authors: Sam Williams <sam@arweave.org>
+
+## Abstract
+
+This standard outlines a mechanism for arbitrarily tagging any transaction on the permaweb with the license under which it is published. The standard focuses on simplicity and ease of use in order to encourage broad adoption across the permaweb ecosystem.
+
+## Motivation
+
+The goal of the Arweave ecosystem is to create a permanent, collective commons of all valuable knowledge and history, available to all people at any time. Just like the original web, by its open nature this ecosystem encourages wide reuse and copying of data. On the traditional web, this has led to a broad corpus of widely shared information that lacks associated licensing data.
+
+By making simple use of the tagging system exposed by Arweave transactions and data entries we can avoid a repeat of this situation, and instead build a web where it is common practice to communicate the license of any piece of data. Due to the inseparable nature of Arweave tags from their associated data, the licensing data of all complying transactions will be _atomically_ communicated to uses -- it is impossible to communicate a link to the data, without also transmitting its licensing information. Due to the nature of Arweave's tagging system, this is achieved without any mandatory or noticeable effect on user experience (when the data is rendered in browsers, etc).
+
+## Specification
+
+The license tagging format is composed of a single additional tag on any transaction on the Arweave network, as well as two additional transaction formats for defining license types.
+
+### Assigning a License to Transaction Data
+
+In order to publish the data of a transaction under a given transaction format, simply add the following tag:
+
+| Tag Name | _Optional?_ | Tag Value |
+|---|---|---|
+|License|False|TXID of `License Definition`|
+
+### License Definitions
+
+In order to define a license, submit a transaction with the following tags:
+
+| Tag Name | _Optional?_ | Tag Value |
+|---|---|---|
+|App-Name|True|`"License-Definition"`|
+|Logo|True|TXID of `License Logo`|
+|Short-Name|True|A short 'ticker' with which to refer to the license|
+|Content-Type|True|The MIME type of the contained file, describing the license.|
+
+The **body** of the transaction must contain the legal text of the license being defined.
+
+### License Logos
+
+License Logo transactions should be defined as follows:
+
+| Tag Name | _Optional?_ | Tag Value |
+|---|---|---|
+|Content-Type|False|The MIME type of the contained file.|
+
+The **body** of the transaction must contain the visual representation of the license's logo.
+
+## Future Work
+
+The presented license standard represents a simple and effective method of defining licenses for all types of data on the Arweave network. In the future, this standard could be extended to support interactive (smart contract) mechanisms for issuing potential updates to a piece of content’s license.

--- a/ans/ANS-105.md
+++ b/ans/ANS-105.md
@@ -46,7 +46,7 @@ In order to define a license or related legal tool (such as [CC0](https://wiki.c
 |---|---|---|
 |App-Name|True|`"License-Definition"`|
 |Logo|True|TXID of `License Logo`|
-|Short-Name|True|A short 'ticker' with which to refer to the license|
+|Short-Name|True|A short (max 64 characters) 'ticker' with which to refer to the license|
 |Content-Type|True|The MIME type of the contained file, describing the license|
 
 The **body** of the transaction must contain the legal text of the license being defined.

--- a/ans/ANS-105.md
+++ b/ans/ANS-105.md
@@ -2,7 +2,7 @@
 
 Status: Draft-2
 
-Authors: Sam Williams <sam@arweave.org>
+Authors: Sam Williams <sam@arweave.org>, Abhav Kedia <abhav@arweave.org>
 
 ## Abstract
 
@@ -29,8 +29,16 @@ In order to publish the data of a transaction under a given transaction format, 
 |Creator|True|The name/identifier of the creator(s) of the work|
 |Source|True|A link to the source where the material was obtained, if applicable|
 
+### License Assertion
 
-### License or Legal tool Definitions
+In order to assert that a previously uploaded transaction has a given license, provide the following tags: 
+| Tag Name | _Optional?_ | Tag Value |
+|---|---|---|
+|App-Name|False|"License-Assertion"|
+|License|False|TXID of updated `License Definition`|
+|Original|False|TXID of original upload|
+
+### License or Legal Tool Definitions
 
 In order to define a license or related legal tool (such as [CC0](https://wiki.creativecommons.org/wiki/CC0)), submit a transaction with the following tags:
 

--- a/ans/ANS-105.md
+++ b/ans/ANS-105.md
@@ -34,7 +34,7 @@ In order to publish the data of a transaction under a given transaction format, 
 In order to assert that a previously uploaded transaction has a given license, provide the following tags: 
 | Tag Name | _Optional?_ | Tag Value |
 |---|---|---|
-|App-Name|False|"License-Assertion"|
+|App-Name|False|`"License-Assertion"`|
 |License|False|TXID of updated `License Definition`|
 |Original|False|TXID of original upload|
 

--- a/ans/ANS-105.md
+++ b/ans/ANS-105.md
@@ -35,8 +35,8 @@ In order to assert that a previously uploaded transaction has a given license, p
 | Tag Name | _Optional?_ | Tag Value |
 |---|---|---|
 |App-Name|False|`"License-Assertion"`|
-|License|False|TXID of updated `License Definition`|
 |Original|False|TXID of original upload|
+|License|False|TXID of updated `License Definition`|
 
 ### License or Legal Tool Definitions
 


### PR DESCRIPTION
Hi all!

Let's use this pull request to discuss the upcoming ANS-105 License Tags standard.

As outlined in the abstract, this standard attempts to be as simple and clear as possible, focusing on making integration as easy as possible for new devs. This, I think, gives us the best likelihood of gaining widespread adoption in the ecosystem -- particularly given that there is no _direct_ incentive for many applications to pick this up. Licenses tend to be fairly low on the list of priorities when new devs start to build their apps. If we make it simple enough, hopefully they will adopt it anyway. Adding complexity introduces the possibility that it will be ignored.

This note on implementation complexity aside, open to any and all feedback!

-arweave-sam