### PR TITLE
Update `offset` to `size`

### DIFF
--- a/ans/ANS-104.md
+++ b/ans/ANS-104.md
@@ -48,7 +48,7 @@ This format for the transaction body is binary data in the following bytes forma
 | Bytes                              | Purpose                                       |
 |---                                 |---                                            |
 |32                                  |Numbers of data items                          |
-|`N` x 64                            |Pairs of offset and entry ids [offset (32 bytes), entry ID (32 bytes)]|
+|`N` x 64                            |Pairs of size and entry ids [size (32 bytes), entry ID (32 bytes)]|
 |Remaining bytes                     |Binary encoded data items in bundle            |
 
 #### 1.3 DataItem Format


### PR DESCRIPTION
Looking at a bundle on the chain, it looks like this field is the size of the dataitem, and not its offset.

The bundle I looked at was QaxLv87sMumEGCqKudjDP8JBiT5r0fYP4-VZB0An4s0 .