### PR TITLE
ANS-112: Digital Content Provenance Records

### DIFF
--- a/ans/ANS-112.md
+++ b/ans/ANS-112.md
@@ -1,0 +1,56 @@
+# ANS-112: Digital Content Provenance Records
+
+Status: Draft
+
+Authors: Josh Benaron (<josh@bundlr.network>), David Kong (davidk@arweave.org), Sam Williams (sam@arweave.org).
+
+## Abstract
+
+The Digital Content Provenance Record (DCPR) standard offers a method for providing cryptographically verifiable provenance to individually identified items of data. Digital content and data assets complying to this standard inherit the immutable timestamping and attribution properties of Arweave, guaranteeing a permanent and tamper-proof record of provenance. This open standard can be adopted by anyone without restriction, hosted on the permissionless Arweave blockchain protocol.
+
+## Motivation
+
+As innovations in AI technology advance rapidly, the provenance of digital content becomes increasingly important. Artists, politicians and other public figures can now be impersonated or mischaracterized convincingly. The DCPR standard provides a provably neutral ledger for recording and safeguarding legitimacy of digital information. Specifically, it provides:
+
+- Cryptographically verifiable records of metadata (authorship assertions, licenses, etc);
+- Provable timestamps through decentralized consensus;
+- Permissionless additions by any party;
+- Open indexing and querying of all records;
+- While optionally allowing the data itself to be kept private.
+
+## Specification
+
+### 1. Data format
+
+#### 1.1 Data tags
+
+A provenance proof must include the following tags:
+    
+
+| Name          | Value                                                                                    | Purpose                                                                         | Optional           |
+|---------------|------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|--------------------|
+| Data-Protocol | `Provenance-Confirmation`                                                                   | Provides ability to identify all Creative Commons transactions                  | :x:                |
+| Hashing-Algo  | `string` - Hash algorithm used on the data to generate `Data-Hash`. Defaults to `sha256` | Provides ability to use different has alogrithm within the standard             | :heavy_check_mark: |
+| Data-Hash     | `string` - Hash of the data using the `Hashing-Algo` algorithm                           | Provides an easy content integrity check                                        | :x: |
+| Uploaded-For  | `string` - Identifier of the person that the data relates to                             | Provides an easy attribution method for the uploader                            | :heavy_check_mark: |
+| Prompt        | `string` - The prompt that led to the generation of the data                             | Allows for a prompt                                                             | :heavy_check_mark: |
+| Prompt-Hash   | `string` - A hash of the prompt that led to the generation of the data                   | Allows for a private prompt which can act as a proof if it needs to be revealed | :heavy_check_mark: |
+| Model         | `string` - Identifier of model used to generate data                                     | Allows searchability based on the model the data relates to you                 | :heavy_check_mark: |
+
+
+#### 1.2 Hashing Algorithm
+
+The Digital Content Provenance Standard does not hold an opinion on which hashing algorithms to support. Specifying a hashing algorithm is left to the discretion of the users and distributors of the standard. 
+
+#### 1.2 Content Data
+
+Storing the entire data file for a corresponding piece of digital content is optional. The `Data-Hash` value of the data asset is sufficient to verify provenance.
+
+
+### 2. Record Validation
+
+A provenance proof is valid if and only if:
+- `Data-Protocol` is `DCPR`.
+- `Hashing-Algo` is a valid hashing algorithm name (identified by its RFC-6234 form).
+- when `Prompt-Hash` and `Prompt` are present, then `Prompt` must hash to the same value as the value stored in the `Prompt-Hash` tag.
+- when the content's data is present it must hash to the same value as the value stored in the `Data-Hash` tag.


### PR DESCRIPTION
This PR offers ANS-112, a standardized format for content provenance records.

An (impermanent) demo of an application implementing the present version of the specification has been devised by @joshbenaron.